### PR TITLE
🔧 Enable `dependabot` for GitHub Action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: weekly
       time: "04:00"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "04:00"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR enables dependabot for GitHub Action dependencies.