### PR TITLE
🔥 Remove `gitDecorations` use default ones

### DIFF
--- a/src/colors/dark.ts
+++ b/src/colors/dark.ts
@@ -63,11 +63,6 @@ export default {
       softRed: "#FF5370",
       softViolet: "#C792EA",
     },
-    git: {
-      added: "#DAE56D",
-      conflicting: "#67F0FF",
-      modified: "#FACC73",
-    },
     gutter: {
       added: "#d4e157",
       deleted: "#FF5252",

--- a/src/colors/light.ts
+++ b/src/colors/light.ts
@@ -63,11 +63,6 @@ export default {
       softRed: "#D73B5B",
       softViolet: "#9B59C9",
     },
-    git: {
-      added: "#1a7f37",
-      conflicting: "#8250df",
-      modified: "#FACC73",
-    },
     gutter: {
       added: "#4ac26b",
       deleted: "#ff8182v",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -58,13 +58,6 @@ const theme = (type: Variant): Theme => {
       "editorRuler.foreground": colors.editor.ruler,
       "editorWidget.background": colors.canvas.background.default,
       focusBorder: colors.canvas.border.default,
-      "gitDecoration.addedResourceForeground": colors.editor.git.added,
-      "gitDecoration.conflictingResourceForeground":
-        colors.editor.git.conflicting,
-      "gitDecoration.deletedResourceForeground": colors.editor.error,
-      "gitDecoration.modifiedResourceForeground": colors.editor.warning,
-      "gitDecoration.untrackedResourceForeground": colors.editor.git.added,
-      "gitDecoration.renamedResourceForeground": colors.editor.git.added,
       "input.background": colors.canvas.input.background,
       "input.border": colors.canvas.border.inset,
       "inputOption.activeBackground": colors.canvas.inputOption.default,


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR removes the `gitDecorations` from the theme to fallback on the default ones provided by VSCode light/dark 🙏🏼 
