### PR TITLE
♻️ Rename `publish` script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Publish package to Marketplace 🚀
         env:
           VSCODE_PAT: ${{ secrets.VSCODE_TOKEN }}
-        run: npm run publish -- --pat=${{ env.VSCODE_PAT }}
+        run: npm run publish:vsce -- --pat=${{ env.VSCODE_PAT }}
       - name: Publish package to NPM 🚀
         env:
           NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dev": "nodemon --watch src/**",
     "prepare": "husky install",
     "lint": "prettier --check .",
-    "publish": "vsce publish"
+    "publish:vsce": "vsce publish"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
## Description

Rename `publish` script to avoid colliding with `npm publish` built-in command. 